### PR TITLE
chore(credits): add BCCWJ (NINJAL) attribution

### DIFF
--- a/src/app/[locale]/credits/page.tsx
+++ b/src/app/[locale]/credits/page.tsx
@@ -36,6 +36,13 @@ export default function CreditsPage() {
       icon: '📚'
     },
     {
+      name: 'BCCWJ (NINJAL)',
+      description: strings.credits?.sources?.bccwj || 'Word-frequency data from the Balanced Corpus of Contemporary Written Japanese, by the National Institute for Japanese Language and Linguistics (NINJAL), used to rank dictionary search results.',
+      url: 'https://clrd.ninjal.ac.jp/bccwj/en/',
+      license: 'Free for research/educational use',
+      icon: '📈'
+    },
+    {
       name: 'WaniKani',
       description: t('credits.sources.wanikani'),
       url: 'https://www.wanikani.com',


### PR DESCRIPTION
Adds the required **BCCWJ / NINJAL** attribution to the credits page (`/credits` → Data Sources & Content), since the dictionary search now ranks results using BCCWJ word-frequency data (free for research/educational use, attribution required).

Follow-up to #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)