### PR TITLE
fix(credits): BCCWJ attribution build error (type-check)

### DIFF
--- a/src/app/[locale]/credits/page.tsx
+++ b/src/app/[locale]/credits/page.tsx
@@ -37,7 +37,7 @@ export default function CreditsPage() {
     },
     {
       name: 'BCCWJ (NINJAL)',
-      description: strings.credits?.sources?.bccwj || 'Word-frequency data from the Balanced Corpus of Contemporary Written Japanese, by the National Institute for Japanese Language and Linguistics (NINJAL), used to rank dictionary search results.',
+      description: 'Word-frequency data from the Balanced Corpus of Contemporary Written Japanese, by the National Institute for Japanese Language and Linguistics (NINJAL), used to rank dictionary search results.',
       url: 'https://clrd.ninjal.ac.jp/bccwj/en/',
       license: 'Free for research/educational use',
       icon: '📈'


### PR DESCRIPTION
Fixes the failed production build from #4: `strings.credits.sources.bccwj` is a non-existent typed i18n key. Replaced with a literal string. `tsc --noEmit` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)